### PR TITLE
docs: mark GCP serverless functions as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # coralogix-gcp-serverless
+
+> **[NOTICE]** The functions in this repository (`gcp-gcs`, `gcp-log-exporter` and `gcp-pub-sub`) are deprecated in favor of the [gcp-logs](https://coralogix.com/docs/integrations/gcp/gcp-logs/) pull integration. Please use the new integration for all new GCP logs integrations. [terraform-provider-coralogix](https://github.com/coralogix/terraform-provider-coralogix) provides the `coralogix_integration` resource for this.
+
 This repository will contain the code examples for using Coralogix on GCP

--- a/gcp-gcs/README.md
+++ b/gcp-gcs/README.md
@@ -82,7 +82,7 @@ region = "us-central1"
 module "storage" {
   source = "coralogix/google/coralogix//modules/storage"
 
-  coralogix_region = "Europe"
+  coralogix_region = "EU1"
   private_key      = "YOUR_API_KEY"
   application_name = "GCP"
   subsystem_name   = "GCS"

--- a/gcp-gcs/README.md
+++ b/gcp-gcs/README.md
@@ -82,7 +82,7 @@ region = "us-central1"
 module "storage" {
   source = "coralogix/google/coralogix//modules/storage"
 
-  coralogix_region = "EU1"
+  coralogix_region = "Europe"
   private_key      = "YOUR_API_KEY"
   application_name = "GCP"
   subsystem_name   = "GCS"

--- a/gcp-gcs/README.md
+++ b/gcp-gcs/README.md
@@ -10,25 +10,30 @@ Coralogix provides a predefined function to forward your logs from Google Cloud 
 
 There are two methods to deploy this integration. The first is using gcloud cli, and the second is to use our Terraform module.
 
-For the gcloud cli method, you will need to select the coralogix domain endpoint that corresponds to your Coralogix AWS region from the table below. You will also need a service account with the necessary permissions to invoke the function, access storage buckets and objects, and receive Eventarc events. Check the Service Account Setup section below for example steps to create the service account and custom role.
+For the gcloud cli method, you will need to select the coralogix domain endpoint that corresponds to your Coralogix region from the table below. You will also need a service account with the necessary permissions to invoke the function, access storage buckets and objects, and receive Eventarc events. Check the Service Account Setup section below for example steps to create the service account and custom role.
 
 ### Coralogix Legacy Logs API
 
-| Coralogix Domain | Coralogix AWS Region | Endpoint |
+| Coralogix Domain | Cloud Provider Region | Endpoint |
 | --- | --- | --- |
-| coralogix.com | eu-west-1<br/>[EU1 - Ireland] | https://ingress.coralogix.com/api/v1/logs |
-| coralogix.in | ap-south1<br/>[AP1 - India] | https://ingress.coralogix.in/api/v1/logs |
-| coralogix.us | us-east2<br/>[US1 - Ohio] | https://ingress.coralogix.us/api/v1/logs |
-| eu2.coralogix.com | eu-north-1<br/>[EU2 - Stockholm] | https://ingress.eu2.coralogix.com/api/v1/logs |
-| coralogixsg.com | ap-southeast-1<br/>[AP2 - Singapore] | https://ingress.coralogixsg.com/api/v1/logs |
-| cx498.coralogix.com | us-west-2<br/>[US2 - Oregon] | https://ingress.cx498.coralogix.com/api/v1/logs |
-| ap3.coralogix.com | ap-southeast-3<br/>[AP3 - Jakarta] | https://ingress.ap3.coralogix.com/api/v1/logs |
+| eu1.coralogix.com | AWS eu-west-1<br/>[EU1 - Ireland] | https://ingress.eu1.coralogix.com/api/v1/logs |
+| eu2.coralogix.com | AWS eu-north-1<br/>[EU2 - Stockholm] | https://ingress.eu2.coralogix.com/api/v1/logs |
+| us1.coralogix.com | AWS us-east-2<br/>[US1 - Ohio] | https://ingress.us1.coralogix.com/api/v1/logs |
+| us2.coralogix.com | AWS us-west-2<br/>[US2 - Oregon] | https://ingress.us2.coralogix.com/api/v1/logs |
+| ap1.coralogix.com | AWS ap-south-1<br/>[AP1 - Mumbai] | https://ingress.ap1.coralogix.com/api/v1/logs |
+| ap2.coralogix.com | AWS ap-southeast-1<br/>[AP2 - Singapore] | https://ingress.ap2.coralogix.com/api/v1/logs |
+| ap3.coralogix.com | AWS ap-southeast-3<br/>[AP3 - Jakarta] | https://ingress.ap3.coralogix.com/api/v1/logs |
 
-For example, if your top level domain is coralogix.us, use the following as your endpoints:
+**NOTE** - The `US3` region (`us3.coralogix.com`, GCP us-central1) does not serve the legacy Logs API that this
+integration uses, so it is not listed above. See the
+[Coralogix domain](https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/)
+documentation for the full list of regions.
+
+For example, if your Coralogix domain is us1.coralogix.com, use the following as your endpoints:
 
 ``` bash
-CORALOGIX_LOG_URL=https://ingress.coralogix.us/api/v1/logs
-CORALOGIX_TIME_DELTA_URL=https://ingress.coralogix.us/sdk/v1/time
+CORALOGIX_LOG_URL=https://ingress.us1.coralogix.com/api/v1/logs
+CORALOGIX_TIME_DELTA_URL=https://ingress.us1.coralogix.com/sdk/v1/time
 ```
 
 ### gcloud CLI
@@ -55,7 +60,7 @@ gcloud functions deploy gcsToCoralogix \
 --trigger-resource=YOUR_BUCKET_NAME \
 --trigger-event=google.storage.object.finalize \
 --service-account=YOUR_SERVICE_ACCOUNT_EMAIL \
---set-env-vars="private_key=YOUR_PRIVATE_KEY,app_name=APP_NAME,sub_name=SUB_NAME,CORALOGIX_LOG_URL=https://ingress.coralogix.com/api/v1/logs,CORALOGIX_TIME_DELTA_URL=https://ingress.coralogix.com/sdk/v1/time"
+--set-env-vars="private_key=YOUR_PRIVATE_KEY,app_name=APP_NAME,sub_name=SUB_NAME,CORALOGIX_LOG_URL=https://ingress.eu1.coralogix.com/api/v1/logs,CORALOGIX_TIME_DELTA_URL=https://ingress.eu1.coralogix.com/sdk/v1/time"
 ```
 
 After deploying, double check your Google Cloud console to validate the Cloud Function was deployed as expected.

--- a/gcp-gcs/README.md
+++ b/gcp-gcs/README.md
@@ -4,6 +4,8 @@ date: "2025-01-30"
 coverImage: "icon_cloud_192pt_clr-1.png"
 ---
 
+> **[NOTICE]** This function is deprecated in favor of the [gcp-logs](https://coralogix.com/docs/integrations/gcp/gcp-logs/) pull integration. Please use the new integration for all new GCP logs integrations. [terraform-provider-coralogix](https://github.com/coralogix/terraform-provider-coralogix) provides the `coralogix_integration` resource for this.
+
 Coralogix provides a predefined function to forward your logs from Google Cloud Platform (GCP) Storage straight to Coralogix.
 
 ## Setup

--- a/gcp-gcs/README.md
+++ b/gcp-gcs/README.md
@@ -10,30 +10,25 @@ Coralogix provides a predefined function to forward your logs from Google Cloud 
 
 There are two methods to deploy this integration. The first is using gcloud cli, and the second is to use our Terraform module.
 
-For the gcloud cli method, you will need to select the coralogix domain endpoint that corresponds to your Coralogix region from the table below. You will also need a service account with the necessary permissions to invoke the function, access storage buckets and objects, and receive Eventarc events. Check the Service Account Setup section below for example steps to create the service account and custom role.
+For the gcloud cli method, you will need to select the coralogix domain endpoint that corresponds to your Coralogix AWS region from the table below. You will also need a service account with the necessary permissions to invoke the function, access storage buckets and objects, and receive Eventarc events. Check the Service Account Setup section below for example steps to create the service account and custom role.
 
 ### Coralogix Legacy Logs API
 
-| Coralogix Domain | Cloud Provider Region | Endpoint |
+| Coralogix Domain | Coralogix AWS Region | Endpoint |
 | --- | --- | --- |
-| eu1.coralogix.com | AWS eu-west-1<br/>[EU1 - Ireland] | https://ingress.eu1.coralogix.com/api/v1/logs |
-| eu2.coralogix.com | AWS eu-north-1<br/>[EU2 - Stockholm] | https://ingress.eu2.coralogix.com/api/v1/logs |
-| us1.coralogix.com | AWS us-east-2<br/>[US1 - Ohio] | https://ingress.us1.coralogix.com/api/v1/logs |
-| us2.coralogix.com | AWS us-west-2<br/>[US2 - Oregon] | https://ingress.us2.coralogix.com/api/v1/logs |
-| ap1.coralogix.com | AWS ap-south-1<br/>[AP1 - Mumbai] | https://ingress.ap1.coralogix.com/api/v1/logs |
-| ap2.coralogix.com | AWS ap-southeast-1<br/>[AP2 - Singapore] | https://ingress.ap2.coralogix.com/api/v1/logs |
-| ap3.coralogix.com | AWS ap-southeast-3<br/>[AP3 - Jakarta] | https://ingress.ap3.coralogix.com/api/v1/logs |
+| coralogix.com | eu-west-1<br/>[EU1 - Ireland] | https://ingress.coralogix.com/api/v1/logs |
+| coralogix.in | ap-south1<br/>[AP1 - India] | https://ingress.coralogix.in/api/v1/logs |
+| coralogix.us | us-east2<br/>[US1 - Ohio] | https://ingress.coralogix.us/api/v1/logs |
+| eu2.coralogix.com | eu-north-1<br/>[EU2 - Stockholm] | https://ingress.eu2.coralogix.com/api/v1/logs |
+| coralogixsg.com | ap-southeast-1<br/>[AP2 - Singapore] | https://ingress.coralogixsg.com/api/v1/logs |
+| cx498.coralogix.com | us-west-2<br/>[US2 - Oregon] | https://ingress.cx498.coralogix.com/api/v1/logs |
+| ap3.coralogix.com | ap-southeast-3<br/>[AP3 - Jakarta] | https://ingress.ap3.coralogix.com/api/v1/logs |
 
-**NOTE** - The `US3` region (`us3.coralogix.com`, GCP us-central1) does not serve the legacy Logs API that this
-integration uses, so it is not listed above. See the
-[Coralogix domain](https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/)
-documentation for the full list of regions.
-
-For example, if your Coralogix domain is us1.coralogix.com, use the following as your endpoints:
+For example, if your top level domain is coralogix.us, use the following as your endpoints:
 
 ``` bash
-CORALOGIX_LOG_URL=https://ingress.us1.coralogix.com/api/v1/logs
-CORALOGIX_TIME_DELTA_URL=https://ingress.us1.coralogix.com/sdk/v1/time
+CORALOGIX_LOG_URL=https://ingress.coralogix.us/api/v1/logs
+CORALOGIX_TIME_DELTA_URL=https://ingress.coralogix.us/sdk/v1/time
 ```
 
 ### gcloud CLI
@@ -60,7 +55,7 @@ gcloud functions deploy gcsToCoralogix \
 --trigger-resource=YOUR_BUCKET_NAME \
 --trigger-event=google.storage.object.finalize \
 --service-account=YOUR_SERVICE_ACCOUNT_EMAIL \
---set-env-vars="private_key=YOUR_PRIVATE_KEY,app_name=APP_NAME,sub_name=SUB_NAME,CORALOGIX_LOG_URL=https://ingress.eu1.coralogix.com/api/v1/logs,CORALOGIX_TIME_DELTA_URL=https://ingress.eu1.coralogix.com/sdk/v1/time"
+--set-env-vars="private_key=YOUR_PRIVATE_KEY,app_name=APP_NAME,sub_name=SUB_NAME,CORALOGIX_LOG_URL=https://ingress.coralogix.com/api/v1/logs,CORALOGIX_TIME_DELTA_URL=https://ingress.coralogix.com/sdk/v1/time"
 ```
 
 After deploying, double check your Google Cloud console to validate the Cloud Function was deployed as expected.

--- a/gcp-log-exporter/Readme.md
+++ b/gcp-log-exporter/Readme.md
@@ -1,5 +1,7 @@
 # GCP log exporter
 
+> **[NOTICE]** This function is deprecated in favor of the [gcp-logs](https://coralogix.com/docs/integrations/gcp/gcp-logs/) pull integration. Please use the new integration for all new GCP logs integrations. [terraform-provider-coralogix](https://github.com/coralogix/terraform-provider-coralogix) provides the `coralogix_integration` resource for this.
+
 This repo contains an example of code to use with code functions to export logs from buckets to Coralogix using cloud functions.
 
 ## Installation manual

--- a/gcp-log-exporter/Readme.md
+++ b/gcp-log-exporter/Readme.md
@@ -11,13 +11,10 @@ Coralogix documentations can be found [Here](https://coralogix.com/integrations/
 - app_name - Your application name, this is how you can label your pplications logs.
 - sub_name - Your subsystem name, this is a second label for your applications logs.
 
-If your Coralogix account is not in the `EU1` region, add the following environment variable, using the
-[Coralogix domain](https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/)
-for your region:
+If your Coralogix account top level domain is different than ‘.com’ add the following environment variable, 
 ```
-CORALOGIX_LOG_URL=https://ingress.<CORALOGIX_DOMAIN>/api/v1/logs
+CORALOGIX_LOG_URL=https://<Cluster URL>/api/v1/logs
 ```
-For example, an account on `us1.coralogix.com` uses `https://ingress.us1.coralogix.com/api/v1/logs`.
 
 Requirements:
 -------------
@@ -44,4 +41,4 @@ To setup the function, execute this:
 		--trigger-bucket=<YOUR_STORAGE_BUCKET_NAME> \
 		--source=gcp-log-exporter \
 		--set-env-vars="private_key=<YOUR_PRIVATE_KEY>,app_name=<APP_NAME>,sub_name=<SUB_NAME>"
-	# additional variables available and their defaults: 'newline_pattern=/(?:\r\n|\r|\n)/g', 'CORALOGIX_LOG_URL=https://ingress.<CORALOGIX_DOMAIN>/api/v1/logs'
+	# additional variables available and their defaults: 'newline_pattern=/(?:\r\n|\r|\n)/g', 'CORALOGIX_LOG_URL=https://<Cluster URL>/api/v1/logs'

--- a/gcp-log-exporter/Readme.md
+++ b/gcp-log-exporter/Readme.md
@@ -5,7 +5,7 @@
 This repo contains an example of code to use with code functions to export logs from buckets to Coralogix using cloud functions.
 
 ## Installation manual
-Coralogix documentations can be found [Here](https://coralogix.com/integrations/gcp-log-explorer/)
+Coralogix documentations can be found [Here](https://coralogix.com/docs/integrations/gcp/gcp-log-explorer/)
 
 ## Configuration
 ### A few basic environment variables are required here:

--- a/gcp-log-exporter/Readme.md
+++ b/gcp-log-exporter/Readme.md
@@ -11,10 +11,13 @@ Coralogix documentations can be found [Here](https://coralogix.com/integrations/
 - app_name - Your application name, this is how you can label your pplications logs.
 - sub_name - Your subsystem name, this is a second label for your applications logs.
 
-If your Coralogix account top level domain is different than ‘.com’ add the following environment variable, 
+If your Coralogix account is not in the `EU1` region, add the following environment variable, using the
+[Coralogix domain](https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/)
+for your region:
 ```
-CORALOGIX_LOG_URL=https://<Cluster URL>/api/v1/logs
+CORALOGIX_LOG_URL=https://ingress.<CORALOGIX_DOMAIN>/api/v1/logs
 ```
+For example, an account on `us1.coralogix.com` uses `https://ingress.us1.coralogix.com/api/v1/logs`.
 
 Requirements:
 -------------
@@ -41,4 +44,4 @@ To setup the function, execute this:
 		--trigger-bucket=<YOUR_STORAGE_BUCKET_NAME> \
 		--source=gcp-log-exporter \
 		--set-env-vars="private_key=<YOUR_PRIVATE_KEY>,app_name=<APP_NAME>,sub_name=<SUB_NAME>"
-	# additional variables available and their defaults: 'newline_pattern=/(?:\r\n|\r|\n)/g', 'CORALOGIX_LOG_URL=https://<Cluster URL>/api/v1/logs'
+	# additional variables available and their defaults: 'newline_pattern=/(?:\r\n|\r|\n)/g', 'CORALOGIX_LOG_URL=https://ingress.<CORALOGIX_DOMAIN>/api/v1/logs'

--- a/gcp-pub-sub/README.rst
+++ b/gcp-pub-sub/README.rst
@@ -1,6 +1,13 @@
 Google Cloud Pub/Sub
 ====================
 
+.. warning::
+
+   **[NOTICE]** This function is deprecated in favor of the `gcp-logs <https://coralogix.com/docs/integrations/gcp/gcp-logs/>`_ pull integration.
+   Please use the new integration for all new GCP logs integrations.
+   `terraform-provider-coralogix <https://github.com/coralogix/terraform-provider-coralogix>`_ provides the ``coralogix_integration`` resource for this.
+   Runtime support for `nodejs14 <https://cloud.google.com/functions/docs/runtime-support#node.js>`_ on Cloud Run Functions will decommission soon.
+
 *Coralogix* provides a predefined function to forward your logs from ``Google Cloud Pub/Sub`` straight to *Coralogix*.
 
 Requirements:


### PR DESCRIPTION
## What changed

Adds a deprecation notice to this repository's README and to each function README, and fixes one broken documentation link. **No functional, endpoint, or domain changes.**

| File | Change |
|---|---|
| `README.md` | repo-level notice, names all three functions |
| `gcp-gcs/README.md` | function-level notice |
| `gcp-log-exporter/Readme.md` | function-level notice + broken docs link fixed |
| `gcp-pub-sub/README.rst` | function-level notice, plus the nodejs14 runtime warning |

The wording mirrors the existing notice in [`terraform-coralogix-google/modules/README.md`](https://github.com/coralogix/terraform-coralogix-google/tree/master/modules/README.md):

> **[NOTICE]** This function is deprecated in favor of the [gcp-logs](https://coralogix.com/docs/integrations/gcp/gcp-logs/) pull integration. Please use the new integration for all new GCP logs integrations. [terraform-provider-coralogix](https://github.com/coralogix/terraform-provider-coralogix) provides the `coralogix_integration` resource for this.

`gcp-pub-sub` additionally retains the upstream *"Runtime support for nodejs14 on Cloud Run Functions will decommission soon"* line, since its deployment example still specifies `--runtime=nodejs14`.

### Broken link fix

`gcp-log-exporter/Readme.md` pointed at `https://coralogix.com/integrations/gcp-log-explorer/`, which `301`s to a malformed target:

```
https://coralogix.com/https/coralogixcom/docs/integrations/gcp/gcp-log-explorer/
```

Now points at `https://coralogix.com/docs/integrations/gcp/gcp-log-explorer/`, which returns `200` with no redirect.

## Why

The v1 Terraform modules that deploy these functions (`modules/pubsub` and `modules/storage`) are already marked deprecated upstream, but the functions in this repository carried no such signal — so this code kept attracting maintenance work that should go to the pull integration instead.

`gcp-gcs/main.py` and `terraform-coralogix-google/modules/storage/src/main.py` are byte-identical apart from one copyright year, confirming these are the same integration the upstream notice already covers.

Worth noting for reviewers: `gcp-gcs` and `gcp-log-exporter` are also the **same function as each other** — their `main.py` files differ only in version string, date, and where `get_severity` is scoped (`gcp-gcs` is the older v1.0.0/2021 copy; `gcp-log-exporter` is v1.0.1/2022).

## Scope note

This PR started as a legacy → regional domain migration (`coralogix.us` → `us1.coralogix.com`, `cx498.coralogix.com` → `us2.coralogix.com`, and so on). That work is **reverted** — updating endpoint tables in a deprecated integration is exactly the maintenance this notice is meant to prevent. The revert commits are on the branch; the net diff is the notices plus the link fix.

## Verification

- `git diff master` touches no endpoint, domain, or region-table line.
- `gcp-pub-sub/README.rst` parses clean under `docutils` (the single warning is a pre-existing missing-Pygments notice on existing `code-block` directives, unrelated to this change).
- The corrected docs link returns `200` with no redirect; the old one was confirmed `301` → malformed URL.
- This repo has no CI, tests, linters, or formatter config, so there are no gates to satisfy.

## Public docs follow-up (separate, not this repo)

The live pages are maintained in `coralogix/docs-docusaurus`, so they need a separate change. Current state:

| Function | Docs page | State |
|---|---|---|
| `gcp-gcs` | [gcp-storage](https://coralogix.com/docs/integrations/gcp/gcp-storage/) | Live; deprecation notice scoped only to the v1 Terraform path, not the function |
| `gcp-log-exporter` | none of its own | Links to [gcp-log-explorer](https://coralogix.com/docs/integrations/gcp/gcp-log-explorer/), which documents a different integration (Pub/Sub push, no cloud function) |
| `gcp-pub-sub` | [google-cloud-pub-sub](https://coralogix.com/docs/google-cloud-pub-sub/) | Already retired — `301` → `gcp-logs` |

Also flagged for the docs team: the `gcp-storage` page instructs setting `CORALOGIX_LOG_URL=.../logs/v1/singles`, but this function ships `coralogix_logger`, which posts the legacy bulk schema (`{privateKey, applicationName, logEntries[]}`) — a different payload from what the singles API accepts.
